### PR TITLE
Settings dialog

### DIFF
--- a/chrome/content/settings.xul
+++ b/chrome/content/settings.xul
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<prefwindow  xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul" title="Reply As Original Recipient">
+	<prefpane style="overflow: auto;">
+		<preferences>
+	    		<preference id="pref_pattern" name="extensions.replyasoriginalrecipient.patterns" type="string" />
+		</preferences>
+		<vbox flex="1">
+			<groupbox flex="1">
+				<caption label="Patterns"/>
+				<vbox>
+					<textbox preference="pref_pattern" id="pattern_textbox"/>
+					<text value="The patterns are matched case insensitive against the full recipient e.g."/>
+					<text value="'My Name &lt;my.name@example.org&gt;' as well as the email (the part between '&lt;' and '&gt;')."/>
+					<text value="Only `*` and `,` have special meaning in the patterns string."/>
+					<text value="Blanks at the beginning and the end are ignored."/>
+					<groupbox flex="1">
+						<caption label="Examples"/>
+						<vbox>
+							<text value="name+*@gmail.com"/>
+							<text value="*@example.org"/>
+							<text value="The default is: *+*"/>
+							<text value="For the same behaviour as “use_plus” set to false in version 1.1: *"/>
+							<text value="Multiple patterns are separated by comma: *@example.org,*+*"/>
+						</vbox>
+					</groupbox>
+				</vbox>
+			</groupbox>
+		</vbox>
+	</prefpane>
+</prefwindow>

--- a/install.rdf
+++ b/install.rdf
@@ -5,11 +5,13 @@
   <RDF:Description RDF:about="urn:mozilla:install-manifest"
                    em:id="replyasoriginalrecipient@qiqitori.com"
                    em:name="Reply As Original Recipient"
-                   em:version="1.2"
+                   em:version="1.3"
                    em:description="Reply with the From: field set to the To: field from the original email."
                    em:creator="Qiqitori"
                    em:homepageURL="http://blog.qiqitori.com/?p=194">
-
+				   
+	<em:optionsURL>chrome://replyasoriginalrecipient/content/settings.xul</em:optionsURL>
+	
     <em:localized>
       <RDF:Description em:locale="en-US"
                        em:name="Reply As Original Recipient"
@@ -38,7 +40,7 @@
 	<em:targetApplication>
 		<Description em:id="{3550f703-e582-4d05-9a08-453d09bdfdc6}"
 			em:minVersion="17.0"
-			em:maxVersion="53.*" />
+			em:maxVersion="69.*" />
 	</em:targetApplication>
   </RDF:Description>
 </RDF:RDF>


### PR DESCRIPTION
I had a little time yesterday to change two more things in the beta:

– A small configuration dialog to enter the pattern. Including a description, but it is only in English.
– Raising the version to 69.*, just so the beta don’t stop working. This is no meant as a stable solution.